### PR TITLE
Add gen jet index

### DIFF
--- a/heptfds/cms_pf/qcd.py
+++ b/heptfds/cms_pf/qcd.py
@@ -1,4 +1,4 @@
-"""CMS PF TTbar dataset."""
+"""CMS PF QCD dataset."""
 
 from pathlib import Path
 import tensorflow as tf
@@ -24,10 +24,11 @@ PADDED_NUM_ELEM_SIZE = 6400
 class CmsPfQcd(tfds.core.GeneratorBasedBuilder):
     """DatasetBuilder for cms_pf dataset."""
 
-    VERSION = tfds.core.Version("1.3.1")
+    VERSION = tfds.core.Version("1.4.0")
     RELEASE_NOTES = {
         "1.3.0": "12_2_0_pre2 generation with updated caloparticle/trackingparticle",
-        "1.3.1": "Remove PS again"
+        "1.3.1": "Remove PS again",
+        "1.4.0": "Add gen jet index information"
     }
     MANUAL_DOWNLOAD_INSTRUCTIONS = """
     FIXME

--- a/heptfds/cms_pf/qcd_high_pt.py
+++ b/heptfds/cms_pf/qcd_high_pt.py
@@ -1,4 +1,4 @@
-"""CMS PF TTbar dataset."""
+"""CMS PF QCD High Pt dataset."""
 
 from pathlib import Path
 import tensorflow as tf
@@ -24,10 +24,11 @@ PADDED_NUM_ELEM_SIZE = 6400
 class CmsPfQcdHighPt(tfds.core.GeneratorBasedBuilder):
     """DatasetBuilder for cms_pf dataset."""
 
-    VERSION = tfds.core.Version("1.3.1")
+    VERSION = tfds.core.Version("1.4.0")
     RELEASE_NOTES = {
         "1.3.0": "12_2_0_pre2 generation with updated caloparticle/trackingparticle",
-        "1.3.1": "Remove PS again"
+        "1.3.1": "Remove PS again",
+        "1.4.0": "Add gen jet index information"
     }
     MANUAL_DOWNLOAD_INSTRUCTIONS = """
     FIXME

--- a/heptfds/cms_pf/ttbar.py
+++ b/heptfds/cms_pf/ttbar.py
@@ -24,13 +24,14 @@ PADDED_NUM_ELEM_SIZE = 6400
 class CmsPfTtbar(tfds.core.GeneratorBasedBuilder):
     """DatasetBuilder for cms_pf dataset."""
 
-    VERSION = tfds.core.Version("1.3.1")
+    VERSION = tfds.core.Version("1.4.0")
     RELEASE_NOTES = {
         "1.0.0": "Initial release.",
         "1.1.0": "Add muon type, fix electron GSF association",
         "1.2.0": "12_1_0_pre3 generation, add corrected energy, cluster flags, 20k events",
         "1.3.0": "12_2_0_pre2 generation with updated caloparticle/trackingparticle",
-        "1.3.1": "Remove PS again"
+        "1.3.1": "Remove PS again",
+        "1.4.0": "Add gen jet index information"
     }
     MANUAL_DOWNLOAD_INSTRUCTIONS = """
     mkdir -p data

--- a/heptfds/cms_pf/ztt.py
+++ b/heptfds/cms_pf/ztt.py
@@ -1,4 +1,4 @@
-"""CMS PF TTbar dataset."""
+"""CMS PF ZTT dataset."""
 
 from pathlib import Path
 import tensorflow as tf
@@ -24,10 +24,11 @@ PADDED_NUM_ELEM_SIZE = 6400
 class CmsPfZtt(tfds.core.GeneratorBasedBuilder):
     """DatasetBuilder for cms_pf dataset."""
 
-    VERSION = tfds.core.Version("1.3.1")
+    VERSION = tfds.core.Version("1.4.0")
     RELEASE_NOTES = {
         "1.3.0": "12_2_0_pre2 generation with updated caloparticle/trackingparticle",
-        "1.3.1": "Remove PS again"
+        "1.3.1": "Remove PS again",
+        "1.4.0": "Add gen jet index information"
     }
     MANUAL_DOWNLOAD_INSTRUCTIONS = """
     mkdir -p data

--- a/heptfds/cms_utils.py
+++ b/heptfds/cms_utils.py
@@ -1,15 +1,19 @@
+from configparser import MAX_INTERPOLATION_DEPTH
 import pickle
 import bz2
 
 import numpy as np
 from numpy.lib.recfunctions import append_fields
+import fastjet
+import vector
+import awkward as ak
 
 
-#https://github.com/ahlinist/cmssw/blob/1df62491f48ef964d198f574cdfcccfd17c70425/DataFormats/ParticleFlowReco/interface/PFBlockElement.h#L33
+# https://github.com/ahlinist/cmssw/blob/1df62491f48ef964d198f574cdfcccfd17c70425/DataFormats/ParticleFlowReco/interface/PFBlockElement.h#L33
 ELEM_LABELS_CMS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
 ELEM_NAMES_CMS = ["NONE", "TRACK", "PS1", "PS2", "ECAL", "HCAL", "GSF", "BREM", "HFEM", "HFHAD", "SC", "HO"]
 
-#https://github.com/cms-sw/cmssw/blob/master/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc#L254
+# https://github.com/cms-sw/cmssw/blob/master/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc#L254
 CLASS_LABELS_CMS = [0, 211, 130, 1, 2, 22, 11, 13]
 CLASS_NAMES_CMS = ["none", "ch.had", "n.had", "HFHAD", "HFEM", "gamma", "ele", "mu"]
 CLASS_NAMES_LONG_CMS = ["none" "charged hadron", "neutral hadron", "hfem", "hfhad", "photon", "electron", "muon"]
@@ -37,12 +41,17 @@ Y_FEATURES = [
     "sin_phi",
     "cos_phi",
     "e",
+    "jet_idx"
 ]
 
 def prepare_data_cms(fn, padded_num_elem_size):
     Xs = []
     ygens = []
     ycands = []
+
+    # prepare jet definition and min jet pt for clustering gen jets 
+    jetdef = fastjet.JetDefinition(fastjet.antikt_algorithm, 0.4)
+    min_jet_pt = 5.0 # GeV
 
     if fn.endswith(".pkl"):
         data = pickle.load(open(fn, "rb"), encoding="iso-8859-1")
@@ -67,10 +76,16 @@ def prepare_data_cms(fn, padded_num_elem_size):
         ygen = append_fields(
             ygen, "typ_idx", np.array([CLASS_LABELS_CMS.index(abs(int(i))) for i in ygen["typ"]], dtype=np.float32)
         )
+        ygen = append_fields(
+            ygen, "jet_idx", np.zeros(ygen["typ"].shape, dtype=np.float32)
+        )
         ycand = append_fields(
             ycand,
             "typ_idx",
             np.array([CLASS_LABELS_CMS.index(abs(int(i))) for i in ycand["typ"]], dtype=np.float32),
+        )
+        ycand = append_fields(
+            ycand, "jet_idx", np.zeros(ycand["typ"].shape, dtype=np.float32)
         )
 
         Xelem_flat = np.stack(
@@ -115,6 +130,33 @@ def prepare_data_cms(fn, padded_num_elem_size):
         X = np.expand_dims(X, 0)
         ygen = np.expand_dims(ygen, 0)
         ycand = np.expand_dims(ycand, 0)
+
+        # prepare gen candidates for clustering
+        cls_id = ygen[:, :, 0]
+        valid = (cls_id != 0)
+        pt = ak.from_iter([y[m] for y, m in zip(ygen[:, :, Y_FEATURES.index("pt")], valid)])
+        eta = ak.from_iter([y[m] for y, m in zip(ygen[:, :, Y_FEATURES.index("eta")], valid)])
+        phi = np.arctan2(ygen[:, :, Y_FEATURES.index("sin_phi")], ygen[:, :, Y_FEATURES.index("cos_phi")])
+        phi = ak.from_iter([y[m] for y, m in zip(phi, valid)])
+        e = ak.from_iter([y[m] for y, m in zip(ygen[:, :, Y_FEATURES.index("e")], valid)])
+        vec = vector.arr({"pt": pt, "eta": eta, "phi": phi, "e": e})
+
+        # cluster jets, sort jet indices in descending order by pt
+        cluster = fastjet.ClusterSequence(vec.to_xyzt(), jetdef)
+        jets = cluster.inclusive_jets(min_pt=min_jet_pt)
+        sorted_jet_idx = ak.argsort(jets.pt, axis=-1, ascending=False).to_list()[0]
+        # retrieve corresponding indices of constituents
+        constituent_idx = cluster.constituent_index(min_pt=min_jet_pt).to_list()[0]
+
+        # add index information to ygen and ycand
+        # index jets in descending order by pt starting from 1:
+        # 0 is null (unclustered),
+        # 1 is 1st highest-pt jet,
+        # 2 is 2nd highest-pt jet, ...
+        for jet_idx in sorted_jet_idx:
+            jet_constituents = constituent_idx[jet_idx]
+            ygen[0, jet_constituents, Y_FEATURES.index("jet_idx")] = jet_idx + 1 # jet index starts from 1
+            ycand[0, jet_constituents, Y_FEATURES.index("jet_idx")] = jet_idx + 1
 
         Xs.append(X)
         ygens.append(ygen)

--- a/heptfds/cms_utils.py
+++ b/heptfds/cms_utils.py
@@ -134,6 +134,11 @@ def prepare_data_cms(fn, padded_num_elem_size):
         # prepare gen candidates for clustering
         cls_id = ygen[:, :, 0]
         valid = (cls_id != 0)
+        # save mapping of index after masking -> index before masking as numpy array
+        # inspired from: https://stackoverflow.com/a/1044443
+        cumsum = np.cumsum(valid) - 1
+        index_mapping = np.nonzero(np.r_[1, np.diff(cumsum)[:-1]])[0]
+
         pt = ak.from_iter([y[m] for y, m in zip(ygen[:, :, Y_FEATURES.index("pt")], valid)])
         eta = ak.from_iter([y[m] for y, m in zip(ygen[:, :, Y_FEATURES.index("eta")], valid)])
         phi = np.arctan2(ygen[:, :, Y_FEATURES.index("sin_phi")], ygen[:, :, Y_FEATURES.index("cos_phi")])
@@ -154,7 +159,7 @@ def prepare_data_cms(fn, padded_num_elem_size):
         # 1 is 1st highest-pt jet,
         # 2 is 2nd highest-pt jet, ...
         for jet_idx in sorted_jet_idx:
-            jet_constituents = constituent_idx[jet_idx]
+            jet_constituents = [index_mapping[idx] for idx in constituent_idx[jet_idx]] # map back to constituent index *before* masking
             ygen[0, jet_constituents, Y_FEATURES.index("jet_idx")] = jet_idx + 1 # jet index starts from 1
             ycand[0, jet_constituents, Y_FEATURES.index("jet_idx")] = jet_idx + 1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 tensorflow>=2.5.0
 tensorflow_datasets==4.3.0
+fastjet

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 tensorflow>=2.5.0
 tensorflow_datasets==4.3.0
 fastjet
+awkward
+vector

--- a/tests/load_cms_pf.py
+++ b/tests/load_cms_pf.py
@@ -3,7 +3,7 @@ import heptfds
 import argparse
 import os
 
-VERSION = "1.3.1"
+VERSION = "1.0.0"
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -23,7 +23,7 @@ def main(args):
     download_config = tfds.download.DownloadConfig(manual_dir=args.manual_dir, max_examples_per_split=args.max_examples_per_split)
 
     train_dataset, train_dataset_info = tfds.load(
-        "cms_pf_ttbar:{}".format(VERSION),
+        "cms_pf:{}".format(VERSION),
         split="train",
         data_dir=args.data_dir,
         as_supervised=False,
@@ -34,7 +34,7 @@ def main(args):
     print("train_dataset_info:\n", train_dataset_info)
 
     test_dataset, test_dataset_info = tfds.load(
-        "cms_pf_ttbar:{}".format(VERSION),
+        "cms_pf:{}".format(VERSION),
         split="test",
         data_dir=args.data_dir,
         as_supervised=False,

--- a/tests/load_cms_pf.py
+++ b/tests/load_cms_pf.py
@@ -3,7 +3,7 @@ import heptfds
 import argparse
 import os
 
-VERSION = "1.0.0"
+VERSION = "1.3.1"
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -23,7 +23,7 @@ def main(args):
     download_config = tfds.download.DownloadConfig(manual_dir=args.manual_dir, max_examples_per_split=args.max_examples_per_split)
 
     train_dataset, train_dataset_info = tfds.load(
-        "cms_pf:{}".format(VERSION),
+        "cms_pf_ttbar:{}".format(VERSION),
         split="train",
         data_dir=args.data_dir,
         as_supervised=False,
@@ -34,7 +34,7 @@ def main(args):
     print("train_dataset_info:\n", train_dataset_info)
 
     test_dataset, test_dataset_info = tfds.load(
-        "cms_pf:{}".format(VERSION),
+        "cms_pf_ttbar:{}".format(VERSION),
         split="test",
         data_dir=args.data_dir,
         as_supervised=False,


### PR DESCRIPTION
Add gen jet index to `ygen` and `ycand` under new feature field called `jet_idx`.

Details:
- Only save indices for jets with `pt` > 5 GeV (as is done for comparison plots)
- "Null" index is `0`(meaning particle is unclustered)
- Jets are sorted in descending order by `pt`
- Jet index starts from `1`, so `1` = 1st highest-pt jet, `2` = 2nd highest-pt jet, ...
- For `ycand`, I wasn't sure if we should recluster based on those candidates, or simply save the same `jet_idx`. What were you thinking @jpata?

